### PR TITLE
Switch BTCPay WC plugin to V2; update WP to 6.0.0; update WC to 6.6.1.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM wordpress:5.5.3
+FROM wordpress:6.0.0
 
-ENV WOOCOMMERCE_VERSION 3.5.5
-ENV BTCPAY_PLUGIN_VERSION 3.0.15
+ENV WOOCOMMERCE_VERSION 6.6.1
+ENV BTCPAY_PLUGIN_VERSION 1.0.2
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends unzip wget \
     && wget https://downloads.wordpress.org/plugin/woocommerce.$WOOCOMMERCE_VERSION.zip -O /tmp/temp.zip \
-    && wget https://downloads.wordpress.org/plugin/btcpay-for-woocommerce.$BTCPAY_PLUGIN_VERSION.zip -O /tmp/temp2.zip \
+    && wget https://downloads.wordpress.org/plugin/btcpay-greenfield-for-woocommerce.$BTCPAY_PLUGIN_VERSION.zip -O /tmp/temp2.zip \
     && cd /usr/src/wordpress/wp-content/plugins \
     && unzip /tmp/temp.zip \
     && unzip /tmp/temp2.zip \


### PR DESCRIPTION
This switches the plugin from the legacy WooCommerce plugin to the new V2 one. Also updates WP and WC to the latest versions.

**Considerations**:
- this docker image is currently tagged with the version of the legacy plugin e.g. `3.0.15` but the new V2 version is `1.0.2` at the moment, so at some point when we reach 3.x with the V2 plugin we will have conflicting tags
- Option 1: do not use the WC plugins tags for this image but either keep going with 3.0.x (could be confusing) or start over with e.g. 4.x to make it clear
- Option 2: fork the repo and create separate image `docker-woocommerce-v2`; I think this will break things as it will be a new container and data volume, right?

I tested this with an existing deployment of the fragment and it worked so that the old config and plugin stayed where it was; also did not install the new V2 plugin as the entrypoint.sh did not run (I assume).

I also ran it by removing the old containers and volumes and it came with lates WP, WC and BTCPay V2 plugins as expected. So it should be save to have it here like this but please double and triple check in case I missed something.

Fixes https://github.com/btcpayserver/btcpayserver/issues/3899